### PR TITLE
Fix Invalid endpoint error in Ch 02 lab

### DIFF
--- a/intro/projects-data/projects-data-nb.ipynb
+++ b/intro/projects-data/projects-data-nb.ipynb
@@ -105,7 +105,7 @@
     "    region,\n",
     "    aws_access_key_id=key_id,\n",
     "    aws_secret_access_key=secret_key,\n",
-    "    endpoint_url=endpoint,\n",
+    "    endpoint_url=\"https://\" + endpoint,\n",
     "    use_ssl=False\n",
     ")"
    ]


### PR DESCRIPTION
When attempting to create a boto3.client, the endpoint_url parameter expects "https://" as part of the URL.  The result is that the following error is thrown when executing step 4 of the notebook:

`ValueError: Invalid endpoint: minio-api-projects-data.apps.ocp4.example.com`

The value is grabbed from the AWS_S3_ENDPOINT environment variable.