### PR TITLE
Update projects-data-nb.ipynb

### DIFF
--- a/intro/projects-data/projects-data-nb.ipynb
+++ b/intro/projects-data/projects-data-nb.ipynb
@@ -18,7 +18,7 @@
    "id": "1b846e72-76c2-4c80-8707-266682759e04",
    "metadata": {},
    "source": [
-    "1. Import the required packages."
+    "1. Install the boto3 and import the required packages."
    ]
   },
   {
@@ -30,6 +30,7 @@
    },
    "outputs": [],
    "source": [
+    "%pip install boto3",
     "import os\n",
     "import io\n",
     "import boto3"


### PR DESCRIPTION
Preventing the "No module boto3" error when running the "import" cell by installing boto3 with pip from the notebook itself.