### PR TITLE
Fix dspa-elyra-runtime image size (8GB -> 1.1GB)

### DIFF
--- a/dspa/elyra/issues_prediction.pipeline
+++ b/dspa/elyra/issues_prediction.pipeline
@@ -18,7 +18,7 @@
           "name": "issues_prediction",
           "runtime": "Data Science Pipelines",
           "pipeline_defaults": {
-            "runtime_image": "registry.ocp4.example.com:8443/redhattraining/dspa-elyra-runtime:v1.0",
+            "runtime_image": "registry.ocp4.example.com:8443/redhattraining/dspa-elyra-runtime:v2.0",
             "env_vars": [],
             "kubernetes_pod_annotations": [],
             "kubernetes_tolerations": [],

--- a/dspa/elyra/resources/Containerfile
+++ b/dspa/elyra/resources/Containerfile
@@ -2,11 +2,13 @@
 # This image extends the Standard Data Science runtime with statsmodels
 # for time series forecasting using SARIMAX models.
 
-FROM quay.io/modh/runtime-images@sha256:c26e71e37d93378cd730d3cbad5744895b7c9a6ee9a0682ab95c40bad8a0062a
+# runtime-datascience-ubi9-python-3.11-20250827
+FROM quay.io/modh/runtime-images@sha256:9a25d14fcc8659bcf9c64918fb2589e03cda223fc55c19fa8337274511d9cf32
 
-# Install statsmodels for time series analysis (SARIMAX forecasting)
-RUN pip install --no-cache-dir statsmodels==0.14.1
+RUN pip install --no-cache-dir statsmodels==0.14.4
 
-# Fix permissions for OpenShift compatibility
-RUN chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
-    fix-permissions /opt/app-root -P
+# Fix permissions on newly installed packages for OpenShift compatibility
+RUN chmod -R g+w /opt/app-root/lib/python3.11/site-packages/statsmodels \
+                 /opt/app-root/lib/python3.11/site-packages/statsmodels-0.14.4.dist-info \
+                 /opt/app-root/lib/python3.11/site-packages/patsy \
+                 /opt/app-root/lib/python3.11/site-packages/patsy-1.0.2.dist-info

--- a/dspa/elyra/resources/build-image.sh
+++ b/dspa/elyra/resources/build-image.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # Image registry and name
 IMAGE_REGISTRY="${IMAGE_REGISTRY:-quay.io/redhattraining}"
 IMAGE_NAME="dspa-elyra-runtime"
-IMAGE_TAG="${IMAGE_TAG:-v1.0}"
+IMAGE_TAG="${IMAGE_TAG:-v2.0}"
 IMAGE="${IMAGE_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"
 
 echo "Building image: ${IMAGE}"


### PR DESCRIPTION
## Summary

- **Root cause:** The Containerfile used a ROCm TensorFlow GPU runtime base image (`rocm-runtime-tensorflow-ubi9-python-3.11`, 7 GB compressed) instead of the Standard Data Science runtime. The GE only needs `pandas`, `boto3`, and `statsmodels` — no GPU stack.
- **Fix:** Switched base to `runtime-datascience-ubi9-python-3.11` (1.06 GB), bumped statsmodels from 0.14.1 to 0.14.4 (numpy 2.x compatible), and scoped `chmod` to only newly installed packages.
- **Result:** Image reduced from **8 GB compressed / 37 GB uncompressed** to **~1.1 GB compressed / 3.1 GB uncompressed** (7x smaller).

## Changes

| File | Change |
|------|--------|
| `dspa/elyra/resources/Containerfile` | Replaced ROCm TF base with Data Science runtime (pinned by digest), bumped statsmodels, targeted chmod |
| `dspa/elyra/resources/build-image.sh` | Updated default tag to `v2.0` |
| `dspa/elyra/issues_prediction.pipeline` | Updated `runtime_image` reference to `v2.0` |

## Verification

- Built image locally with `podman build`
- Verified all GE imports: `statsmodels`, `pandas`, `numpy`, `boto3`, `SARIMAX`
- No numpy downgrade (0.14.4 is compatible with numpy 2.x)
- Pushed to `quay.io/redhattraining/dspa-elyra-runtime:v2.0`

## Companion PR

- LB0006: Updated `vars.yml` image mirror list to reference `v2.0`

## Test plan

- [ ] Deploy on a classroom and run the dspa-elyra GE end-to-end
- [ ] Verify the Elyra pipeline runs successfully with the v2.0 image
- [ ] Confirm image pull times are significantly improved

---

`AIA EAI CeNc Hin R Claude Code, Opus 4.6 v1.0`

Resolves PTL-16573.