### PR TITLE
CDEV-16581: Update Elyra pipeline template for RHOAI 3.3

### DIFF
--- a/dspa/elyra/issues_prediction.pipeline
+++ b/dspa/elyra/issues_prediction.pipeline
@@ -16,9 +16,9 @@
         "runtime_type": "KUBEFLOW_PIPELINES",
         "properties": {
           "name": "issues_prediction",
-          "runtime": "Data Science Pipelines",
+          "runtime": "Pipelines",
           "pipeline_defaults": {
-            "runtime_image": "registry.ocp4.example.com:8443/redhattraining/dspa-elyra-runtime:v1.0",
+            "runtime_image": "registry.lab.example.com:8443/redhattraining/dspa-elyra-runtime:v2.0",
             "env_vars": [],
             "kubernetes_pod_annotations": [],
             "kubernetes_tolerations": [],


### PR DESCRIPTION
## Summary
- Update internal registry hostname from `ocp4.example.com` to `lab.example.com`
- Update runtime image tag from `v1.0` to `v2.0` (matches classroom build `vars.yml`)
- Update runtime label from `Data Science Pipelines` to `Pipelines` (RHOAI 3.3 rename)

## Root cause
Pipeline tasks fail with `ImagePullBackOff` because `registry.ocp4.example.com` does not resolve in RHOAI 3.3 classrooms. Additionally, classroom build only mirrors `v2.0` to the internal registry.

## Test plan
- [ ] `lab start dspa-elyra` succeeds
- [ ] Elyra pipeline submits without "No runtime configuration" error
- [ ] All three pipeline tasks complete (no `ImagePullBackOff`)
- [ ] `lab finish dspa-elyra` succeeds